### PR TITLE
Remove colon

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@ zxc.appendChild(asas)
 userp.appendChild(ded)
 document.getElementById("time").appendChild(zxc) 
 document.getElementById("commenter").appendChild(userp)
- if (!Notification) {
+  if (!window.Notification) {
     alert('Desktop notifications not available in your browser. Try Chromium.'); 
     return;
   }
@@ -104,7 +104,7 @@ document.getElementById("commenter").appendChild(userp)
     Notification.requestPermission();
   else {
     var notification = new Notification(isa, {
-      body: asd
+      body: asd.slice(2)
     });
     notification.onclick = function () {
       window.open("https://jrprogramming.github.io/johnny/HTML%20Code.html#");      


### PR DESCRIPTION
Does this by removing the first two characters of the text, since they'll always be `": "`